### PR TITLE
New Amazon Rules and Intents

### DIFF
--- a/lib/alexa_generator/intent.rb
+++ b/lib/alexa_generator/intent.rb
@@ -44,7 +44,7 @@ module AlexaGenerator
 
     def self.build(name, &block)
       builder = Builder.new(name)
-      block.call(builder)
+      block.call(builder) if block
       builder
     end
   end

--- a/lib/alexa_generator/intent.rb
+++ b/lib/alexa_generator/intent.rb
@@ -3,6 +3,26 @@ require 'alexa_generator/sample_utterance_template'
 
 module AlexaGenerator
   class Intent
+
+    module IntentType
+      CANCEL =      :"AMAZON.CancelIntent"
+      HELP =        :"AMAZON.HelpIntent"
+      LOOP_OFF =    :"AMAZON.LoopOffIntent"
+      LOOP_ON  =    :"AMAZON.LoopOnIntent"
+      NEXT =        :"AMAZON.NextIntent"
+      NO =          :"AMAZON.NoIntent"
+      PAUSE =       :"AMAZON.PauseIntent"
+      PREVIOUS =    :"AMAZON.PreviousIntent"
+      REPEAT =      :"AMAZON.RepeatIntent"
+      RESUME =      :"AMAZON.ResumeIntent"
+      SHUFFLE_OFF = :"AMAZON.ShuffleOffIntent"
+      SHUFFLE_ON =  :"AMAZON.ShuffleOnIntent"
+      START_OVER =  :"AMAZON.StartOverIntent"
+      STOP =        :"AMAZON.StopIntent"
+      YES =         :"AMAZON.YesIntent"
+    end
+
+
     attr_reader :name, :slots
 
     class Builder

--- a/lib/alexa_generator/interaction_model.rb
+++ b/lib/alexa_generator/interaction_model.rb
@@ -62,11 +62,15 @@ module AlexaGenerator
 
     def sample_utterances(intent_name)
       templates = @utterance_templates[intent_name] || []
+      slot_types = collect_slot_types
       utterances = Set.new
 
       templates.each do |template|
         # Consider only the slots that are referenced in this template
         relevant_slots = template.referenced_slots
+
+        # Amazon wants only the LITERAL ones
+        relevant_slots.select! { |s| slot_types[s.to_sym] =~ /LITERAL/  }
 
         # Compute all possible value bindings for the relevant slots
         slot_values = relevant_slots.
@@ -104,6 +108,16 @@ module AlexaGenerator
       utterances.sort.map do |utterance|
         "#{intent_name} #{utterance}"
       end
+    end
+
+    def collect_slot_types
+      out = {}
+      @intents.values.each do |intent|
+        intent.slots.map do |slot|
+          out[slot.name.to_sym] = slot.type.to_s
+        end
+      end
+      out
     end
 
     def self.build(&block)

--- a/lib/alexa_generator/interaction_model.rb
+++ b/lib/alexa_generator/interaction_model.rb
@@ -45,19 +45,25 @@ module AlexaGenerator
     end
 
     def intent_schema
-      {
-          intents: @intents.values.map do |intent|
-            {
-                intent: intent.name,
-                slots: intent.slots.map do |slot|
-                  {
-                      name: slot.name,
-                      type: slot.type
-                  }
-                end
-            }
-          end
-      }
+      out = { intents: [] }
+
+      @intents.values.each do |intent|
+        hash = { intent: intent.name }
+        slots = intent.slots.map do |slot|
+          {
+              name: slot.name,
+              type: slot.type
+          }
+        end
+        
+        if slots.size > 0 || !intent.name =~ /^AMAZON/
+          hash[:slots] = slots
+        end
+
+        out[:intents] << hash
+      end
+
+      out
     end
 
     def sample_utterances(intent_name)

--- a/lib/alexa_generator/slot.rb
+++ b/lib/alexa_generator/slot.rb
@@ -1,11 +1,11 @@
 module AlexaGenerator
   class Slot
     module SlotType
-      LITERAL = :LITERAL
-      NUMBER = :NUMBER
-      DATE = :DATE
-      TIME = :TIME
-      DURATION = :DURATION
+      LITERAL = :"AMAZON.LITERAL"
+      NUMBER = :"AMAZON.NUMBER"
+      DATE = :"AMAZON.DATE"
+      TIME = :"AMAZON.TIME"
+      DURATION = :"AMAZON.DURATION"
     end
 
     class Builder

--- a/spec/alexa_generator/interaction_model_spec.rb
+++ b/spec/alexa_generator/interaction_model_spec.rb
@@ -43,6 +43,54 @@ describe AlexaGenerator::InteractionModel do
                                          })
     end
 
+    it 'should allow built in intents' do
+      iface = AlexaGenerator::InteractionModel.build do |iface|
+        iface.add_intent(AlexaGenerator::Intent::IntentType::CANCEL)
+      end
+
+      expect(iface).to be_an_instance_of(AlexaGenerator::InteractionModel)
+      expect(iface.intent_schema).to eq(
+                                         {
+                                             intents: [
+                                                 {
+                                                     intent: :"AMAZON.CancelIntent"
+                                                 }
+                                             ]
+                                         })
+    end
+
+    it 'should combine custom and built in intents' do
+      iface = AlexaGenerator::InteractionModel.build do |iface|
+        iface.add_intent(AlexaGenerator::Intent::IntentType::CANCEL)
+        iface.add_intent(:IntentOne) do |intent|
+         intent.add_slot(:SlotOne, AlexaGenerator::Slot::SlotType::LITERAL) do |slot|
+            slot.add_binding('value1')
+          end
+
+          intent.add_utterance_template('test {SlotOne} test')
+        end
+      end
+
+      expect(iface).to be_an_instance_of(AlexaGenerator::InteractionModel)
+      expect(iface.intent_schema).to eq(
+                                         {
+                                             intents: [
+                                                 {
+                                                     intent: :"AMAZON.CancelIntent"
+                                                 },
+                                                 {
+                                                     intent: :IntentOne,
+                                                     slots: [
+                                                         {
+                                                             name: :SlotOne,
+                                                             type: AlexaGenerator::Slot::SlotType::LITERAL
+                                                         }
+                                                     ]
+                                                 }
+                                             ]
+                                         })
+    end
+
     it 'should produce bound utterances' do
       iface = AlexaGenerator::InteractionModel.build do |iface|
         iface.add_intent(:MyIntent) do |intent|
@@ -67,15 +115,10 @@ describe AlexaGenerator::InteractionModel do
 
       actual = iface.sample_utterances(:MyIntent)
 
-      expect(actual.count).to eq(8)
-      expect(actual).to include('MyIntent Alexa, please {fix my motorcycle|SlotOne} {one|SlotTwo} at {noon|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {fix my motorcycle|SlotOne} {two|SlotTwo} at {noon|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {make me a sandwich|SlotOne} {one|SlotTwo} at {noon|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {make me a sandwich|SlotOne} {two|SlotTwo} at {noon|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {fix my motorcycle|SlotOne} {one|SlotTwo} at {6 a.m.|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {fix my motorcycle|SlotOne} {two|SlotTwo} at {6 a.m.|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {make me a sandwich|SlotOne} {one|SlotTwo} at {6 a.m.|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {make me a sandwich|SlotOne} {two|SlotTwo} at {6 a.m.|SlotThree}')
+      # only the literal ones get examples
+      expect(actual.count).to eq(2)
+      expect(actual).to include('MyIntent Alexa, please {fix my motorcycle|SlotOne} {SlotTwo} at {SlotThree}')
+      expect(actual).to include('MyIntent Alexa, please {make me a sandwich|SlotOne} {SlotTwo} at {SlotThree}')
     end
   end
 
@@ -144,15 +187,10 @@ describe AlexaGenerator::InteractionModel do
     it 'should produce bound utterances' do
       actual = AlexaGenerator::InteractionModel.new(intents, utterance_templates, slot_bindings).sample_utterances(:MyIntent)
 
-      expect(actual.count).to eq(8)
-      expect(actual).to include('MyIntent Alexa, please {fix my motorcycle|SlotOne} {one|SlotTwo} at {noon|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {fix my motorcycle|SlotOne} {two|SlotTwo} at {noon|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {make me a sandwich|SlotOne} {one|SlotTwo} at {noon|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {make me a sandwich|SlotOne} {two|SlotTwo} at {noon|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {fix my motorcycle|SlotOne} {one|SlotTwo} at {6 a.m.|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {fix my motorcycle|SlotOne} {two|SlotTwo} at {6 a.m.|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {make me a sandwich|SlotOne} {one|SlotTwo} at {6 a.m.|SlotThree}')
-      expect(actual).to include('MyIntent Alexa, please {make me a sandwich|SlotOne} {two|SlotTwo} at {6 a.m.|SlotThree}')
+      # only the literal ones get examples
+      expect(actual.count).to eq(2)
+      expect(actual).to include('MyIntent Alexa, please {fix my motorcycle|SlotOne} {SlotTwo} at {SlotThree}')
+      expect(actual).to include('MyIntent Alexa, please {make me a sandwich|SlotOne} {SlotTwo} at {SlotThree}')
     end
   end
 end


### PR DESCRIPTION
Some changes have been made by Amazon
* Slots now have AMAZON prefix
* Only AMAZON.LITERAL are supposed to include sample utterances
* They have also added new [intents](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/implementing-the-built-in-intents) like "CancelIntent" and such